### PR TITLE
feat: add a command to update license.spdx and language.linguist schemas

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,15 @@
+// Set global shared core
+const lhcore = require('./script/gulp/index.js');
+global.lhcore = lhcore;
+
+// External modules as aliases
+const gulp = lhcore.amd.gulp;
+const hubRegistry = lhcore.amd.hubRegistry;
+
+// Load tasks into the registry of gulp
+hubRegistry([
+    'script/gulp/**/task.*.js',
+]);
+
+gulp.task('default', gulp.series('import'));
+gulp.task('import', gulp.series('pull-submodules', 'import'));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "linterhub.schema",
+  "name": "schema",
   "version": "1.0.0",
   "description": "JSON schemas for linterhub",
+  "scripts": {
+    "gulp": "./node_modules/gulp/bin/gulp.js",
+    "import": "gulp import"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/linterhub/schema.git"
@@ -9,6 +13,15 @@
   "author": "linterhub",
   "license": "MIT",
   "homepage": "https://schema.linterhub.com",
+  "devDependencies": {
+    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp-data": "^1.3.1",
+    "gulp-git": "^2.7.0",
+    "gulp-hub": "^0.8.0",
+    "gulp-json-format": "^2.0.0",
+    "gulp-json-schema": "^1.0.0",
+    "js-yaml": "^3.12.0"
+  },
   "bugs": {
     "url": "https://github.com/linterhub/schema/issues"
   }

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -1,0 +1,19 @@
+{
+    "template": {
+        "linguist": "src/template/language.linguist.json",
+        "spdx": "src/template/license.spdx.json"
+    },
+    "collection": {
+        "dir": "src/collection/",
+        "licenses": {
+            "spdx": "src/collection/license.spdx.json"
+        },
+        "languages": {
+            "linguist": "src/collection/language.linguist.json"
+        }
+    },
+    "ext": {
+        "linguist": "ext/github/linguist/lib/linguist/languages.yml",
+        "spdx": "ext/spdx/license-list-data/json/licenses.json"
+    }
+}

--- a/script/gulp/index.js
+++ b/script/gulp/index.js
@@ -1,0 +1,28 @@
+// Shared conffguration
+const cfg = require('./config.json');
+
+// Shared node modules
+const amd = {
+    fs: require('fs'),
+    git: require('gulp-git'),
+    yaml: require('js-yaml'),
+    gulp: require('gulp'),
+    hubRegistry: require('gulp-hub'),
+    jsonData: require('gulp-data'),
+    jsonFormat: require('gulp-json-format'),
+    jsonSchema: require('gulp-json-schema'),
+};
+
+// Shared functions
+const fnc = {
+    readJson: (path) => JSON.parse(amd.fs.readFileSync(path)),
+    readYaml: (path) => amd.yaml.safeLoad(amd.fs.readFileSync(path)),
+    jsonToBuffer: (json) => Buffer.from(JSON.stringify(json), 'utf8'),
+};
+
+// Exported shared config, modules and functons
+exports = module.exports = {
+    cfg: cfg,
+    amd: amd,
+    fnc: fnc,
+};

--- a/script/gulp/task.git.js
+++ b/script/gulp/task.git.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const git = core.amd.git;
+
+// Update gt submodules
+const pullSubmodules = () => git.updateSubmodule({args: '--init'});
+
+// Tasks
+gulp.task('pull-submodules', pullSubmodules);

--- a/script/gulp/task.import.js
+++ b/script/gulp/task.import.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const jsonData = core.amd.jsonData;
+const jsonFormat = core.amd.jsonFormat;
+const config = core.cfg;
+
+// Externall functions as aliases
+const readJson = core.fnc.readJson;
+const readYaml = core.fnc.readYaml;
+const toBuffer = core.fnc.jsonToBuffer;
+
+// Import licenses from spdx
+const importLicenses = () => gulp
+    .src(config.template.spdx)
+    .pipe(jsonData((file) => {
+        const list = readJson(config.ext.spdx);
+        const template = readJson(file.path);
+        template.enum = list.licenses.map((l) => l.licenseId);
+        file.contents = toBuffer(template);
+        return file;
+    }))
+    .pipe(jsonFormat(4))
+    .pipe(gulp.dest(config.collection.dir));
+
+// Import languages from linguist
+const importLanguages = () => gulp
+    .src(config.template.linguist)
+    .pipe(jsonData((file) => {
+        const list = readYaml(config.ext.linguist);
+        const template = readJson(file.path);
+        const names = Object.keys(list);
+        template.definitions.language.oneOf = names.map((name) => {
+            const item = list[name];
+            const language = {
+                enum: [name],
+            };
+            if (item.extensions && item.extensions.length) {
+                language.extensions = item.extensions;
+            }
+            if (item.filenames && item.filenames.length) {
+                language.filenames = item.filenames;
+            }
+            return language;
+        });
+        file.contents = toBuffer(template);
+        return file;
+    }))
+    .pipe(jsonFormat(4))
+    .pipe(gulp.dest(config.collection.dir));
+
+// Tasks
+gulp.task('import-licenses', importLicenses);
+gulp.task('import-languages', importLanguages);
+gulp.task('import', gulp.parallel('import-licenses', 'import-languages'));

--- a/src/collection/language.linguist.json
+++ b/src/collection/language.linguist.json
@@ -3074,14 +3074,6 @@
                 },
                 {
                     "enum": [
-                        "Pod 6"
-                    ],
-                    "extensions": [
-                        ".pod"
-                    ]
-                },
-                {
-                    "enum": [
                         "PogoScript"
                     ],
                     "extensions": [

--- a/src/template/language.linguist.json
+++ b/src/template/language.linguist.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Collection: programming language and extension",
+    "description": "The set of programming languages and associated file extensions imported from linguist project",
+    "type": "string",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/language"
+        }
+    ],
+    "additionalItems": false,
+    "definitions": {
+        "language": {
+            "title": "Language",
+            "description": "The programming language name",
+            "type": "string",
+            "oneOf": [
+                {}
+            ]
+        }
+    }
+}

--- a/src/template/license.spdx.json
+++ b/src/template/license.spdx.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Collection: software license",
+    "description": "The set of identifiers of software licenses imported from SPDX catalog",
+    "type": "string",
+    "enum": [
+        ""
+    ],
+    "additionalItems": false
+}


### PR DESCRIPTION
added next gulp commands:
- `import-licenses` - import licenses from spdx
- `import-languages` - import languages from linguist
- `pull-submodules` - update git submodules `spdx` and `linguist`
- `import` - `pull-submodules` + `import-licenses` +`import-languages`

added npm command:
- `import` - `gulp import`

Closes #11 