### PR TITLE
feat: add a command to validate schemas

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,5 +11,6 @@ hubRegistry([
     'script/gulp/**/task.*.js',
 ]);
 
-gulp.task('default', gulp.series('import'));
+gulp.task('default', gulp.series('validate'));
 gulp.task('import', gulp.series('pull-submodules', 'import'));
+gulp.task('validate', gulp.series('import', 'validate'));

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -5,12 +5,18 @@
     },
     "collection": {
         "dir": "src/collection/",
+        "mask": "src/collection/*.json",
         "licenses": {
             "spdx": "src/collection/license.spdx.json"
         },
         "languages": {
             "linguist": "src/collection/language.linguist.json"
         }
+    },
+    "schema": {
+        "mask": "src/schema/*.json",
+        "ver": "src/schema/schemaver.json",
+        "draft": "src/collection/draft-06.json"
     },
     "ext": {
         "linguist": "ext/github/linguist/lib/linguist/languages.yml",

--- a/script/gulp/task.validate.js
+++ b/script/gulp/task.validate.js
@@ -1,0 +1,34 @@
+"use strict";
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const jsonSchema = core.amd.jsonSchema;
+const config = core.cfg;
+
+// Validate all core schemas according to schemaver
+const validateCore = () => gulp
+    .src(config.schema.mask)
+    .pipe(jsonSchema({
+        schema: config.schema.ver,
+        loadMissingSchemas: true,
+        checkRecursive: true,
+        verbose: true,
+    }));
+
+// Validate all collection schemas according to schemaver
+const validateCollection = () => gulp
+    .src(config.collection.mask)
+    .pipe(jsonSchema({
+        schema: config.schema.draft,
+        loadMissingSchemas: true,
+        checkRecursive: true,
+        verbose: true,
+    }));
+
+// Tasks
+gulp.task('validate-core', validateCore);
+gulp.task('validate-collection', validateCollection);
+gulp.task('validate', gulp.parallel('validate-core', 'validate-collection'));


### PR DESCRIPTION
added next gulp command:
- `validate-core` - validate core schemas in folder `src/schema`
- `validate-collection`  - validate all collections schemas in folder `src/collection`

added next series command:
- `validate` - included: `import`, 'validate-core` and `validate-collection` commands

Closes #13