### PR TITLE
feat: add build command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,12 @@ hubRegistry([
     'script/gulp/**/task.*.js',
 ]);
 
-gulp.task('default', gulp.series('validate', 'lint'));
+gulp.task('default', gulp.series(
+    'validate',
+    'lint',
+    'build'
+));
 gulp.task('before-commit', gulp.series('pull-submodules', 'lint'));
 gulp.task('import', gulp.series('pull-submodules', 'import'));
 gulp.task('validate', gulp.series('import', 'validate'));
+gulp.task('build', gulp.series('validate', 'lint', 'build'));

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "JSON schemas for linterhub",
   "scripts": {
     "gulp": "./node_modules/gulp/bin/gulp.js",
+    "eslint": "./node_modules/.bin/eslint",
+    "build": "gulp build",
+    "lint": "gulp lint",
     "import": "gulp import"
   },
   "husky": {
@@ -28,6 +31,7 @@
     "gulp-hub": "^0.8.0",
     "gulp-json-format": "^2.0.0",
     "gulp-json-schema": "^1.0.0",
+    "gulp-jsonschema-bundle": "0.0.3",
     "husky": "^1.0.0-rc.8",
     "js-yaml": "^3.12.0"
   },

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -22,7 +22,11 @@
     "schema": {
         "mask": "src/schema/*.json",
         "ver": "src/schema/schemaver.json",
-        "draft": "src/collection/draft-06.json"
+        "draft": "src/collection/draft-06.json",
+        "collection": "src/schema/collection.json"
+    },
+    "build": {
+        "dir": "build"
     },
     "ext": {
         "linguist": "ext/github/linguist/lib/linguist/languages.yml",

--- a/script/gulp/index.js
+++ b/script/gulp/index.js
@@ -12,6 +12,7 @@ const amd = {
     jsonData: require('gulp-data'),
     jsonFormat: require('gulp-json-format'),
     jsonSchema: require('gulp-json-schema'),
+    jsonSchemaBundle: require('gulp-jsonschema-bundle'),
 };
 
 // Shared functions

--- a/script/gulp/task.build.js
+++ b/script/gulp/task.build.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const jsonFormat = core.amd.jsonFormat;
+const jsonSchemaBundle = core.amd.jsonSchemaBundle;
+const config = core.cfg;
+
+// Resolve and inline all $ref in collections
+const bundle = () => gulp
+    .src(config.schema.collection)
+    .pipe(jsonSchemaBundle())
+    .pipe(jsonFormat(4))
+    .pipe(gulp.dest(config.build.dir));
+
+// Copy to build all schemas
+const createBuild = () => gulp
+    .src([
+        config.schema.mask,
+        '!' + config.schema.collection,
+    ])
+    .pipe(gulp.dest(config.build.dir));
+
+// Tasks
+gulp.task('bundle', bundle);
+gulp.task('create-build', createBuild);
+gulp.task('build', gulp.series('bundle', 'create-build'));


### PR DESCRIPTION
added next gulp commands:
- `bundle` - bundle collection schema
- `create-build` - compile core schemas, without collection scheama, and put to build folder

added next gulp series commands:
- `build` - included: `validate`, `lint`, `bundle` and `create-build`

Closes #16