### PR TITLE
test: add test for all schemas in the project

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ hubRegistry([
 gulp.task('default', gulp.series(
     'validate',
     'lint',
-    'build'
+    'build',
+    'test-build'
 ));
 gulp.task('before-commit', gulp.series('pull-submodules', 'lint'));
 gulp.task('import', gulp.series('pull-submodules', 'import'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,13 +11,13 @@ hubRegistry([
     'script/gulp/**/task.*.js',
 ]);
 
+gulp.task('import', gulp.series('pull-submodules', 'import'));
+gulp.task('validate', gulp.series('import', 'validate'));
+gulp.task('build', gulp.series('validate', 'lint', 'build'));
+
 gulp.task('default', gulp.series(
     'validate',
     'lint',
     'build',
     'test-build'
 ));
-gulp.task('before-commit', gulp.series('pull-submodules', 'lint'));
-gulp.task('import', gulp.series('pull-submodules', 'import'));
-gulp.task('validate', gulp.series('import', 'validate'));
-gulp.task('build', gulp.series('validate', 'lint', 'build'));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "gulp": "./node_modules/gulp/bin/gulp.js",
     "eslint": "./node_modules/.bin/eslint",
     "build": "gulp build",
+    "test": "gulp build && gulp test-build",
     "lint": "gulp lint",
     "import": "gulp import"
   },
@@ -24,6 +25,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
+    "fancy-log": "^1.3.2",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-data": "^1.3.1",
     "gulp-eslint": "^4.0.2",
@@ -33,7 +35,8 @@
     "gulp-json-schema": "^1.0.0",
     "gulp-jsonschema-bundle": "0.0.3",
     "husky": "^1.0.0-rc.8",
-    "js-yaml": "^3.12.0"
+    "js-yaml": "^3.12.0",
+    "jsonschema": "^1.2.4"
   },
   "bugs": {
     "url": "https://github.com/linterhub/schema/issues"

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "build": "gulp build",
     "test": "gulp build && gulp test-build",
     "lint": "gulp lint",
-    "import": "gulp import"
+    "import": "gulp import",
+    "update": "git fetch && git rebase && git submodule update --remote --merge"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "gulp before-commit"
+      "pre-commit": "npm run-script test",
+      "post-commit": "npm run-script update"
     }
   },
   "repository": {

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -26,7 +26,12 @@
         "collection": "src/schema/collection.json"
     },
     "build": {
-        "dir": "build"
+        "dir": "build",
+        "mask": "build/*.json"
+    },
+    "test": {
+        "dir": "test",
+        "mask": "test/**/test.json"
     },
     "ext": {
         "linguist": "ext/github/linguist/lib/linguist/languages.yml",

--- a/script/gulp/index.js
+++ b/script/gulp/index.js
@@ -4,6 +4,7 @@ const cfg = require('./config.json');
 // Shared node modules
 const amd = {
     fs: require('fs'),
+    log: require('fancy-log'),
     git: require('gulp-git'),
     yaml: require('js-yaml'),
     eslint: require('gulp-eslint'),
@@ -13,6 +14,7 @@ const amd = {
     jsonFormat: require('gulp-json-format'),
     jsonSchema: require('gulp-json-schema'),
     jsonSchemaBundle: require('gulp-jsonschema-bundle'),
+    jsonSchemaValidator: require('jsonschema').Validator,
 };
 
 // Shared functions

--- a/script/gulp/task.test.js
+++ b/script/gulp/task.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const log = core.amd.log;
+const jsonData = core.amd.jsonData;
+const config = core.cfg;
+const JsonSchemaValidator = core.amd.jsonSchemaValidator;
+
+// External functions as aliases
+const readJson = core.fnc.readJson;
+const validator = new JsonSchemaValidator();
+
+// If result of test is true
+const testTrue = (test, schema, done) => {
+    if (test.valid) {
+        log.info(`OK: ${schema.description} ${test.description}`);
+    } else {
+        log.error(`FAIL: ${schema.description} ${test.description}`);
+        log.error(`FILE: ${test.data.$ref}`);
+        log.error(`MESSAGE: Validation failed`);
+        done();
+    }
+};
+
+// If result of test is false
+const testFalse = (test, schema, done, error) => {
+    if (!test.valid) {
+        log.info(`OK: ${schema.description} ${test.description}`);
+    } else {
+        log.error(`FAIL: ${schema.description} ${test.description}`);
+        log.error(`FILE: ${test.data.$ref}`);
+        error.errors.map((err) => {
+            log.error(`MESSAGE: ${err.message}`);
+            log.error(`SCHEMA PATH: ${err.property}`);
+        });
+        done(error);
+    }
+};
+
+// Run separately test
+const runTest = (test, schema, done) => {
+    const data = readJson(test.data.$ref);
+    const result = validator.validate(data, schema.$schema.$ref);
+    if (result.errors !== 'undefined' && result.errors.length !== 0) {
+        testFalse(test, schema, done, result);
+    } else {
+        testTrue(test, schema, done);
+    }
+};
+
+// Run all json tests
+const test = (done) => gulp
+    .src(config.test.mask)
+    .pipe(jsonData((file) => {
+        const schema = readJson(file.path);
+        const tasks = schema.tests.map((test) => runTest(test, schema, done));
+        return Promise.all(tasks);
+    }));
+
+// Preload schemas in build folder
+const buildPreload = () => gulp
+    .src(config.build.mask)
+    .pipe(jsonData((file) => {
+        const schema = readJson(file.path);
+        validator.addSchema(schema, schema.$id);
+        log.info(`SCHEMA PRELOAD: ${file.path}`);
+    }));
+
+// Tasks
+gulp.task('test-preload-build', buildPreload);
+gulp.task('test-build', gulp.series('test-preload-build', test));
+gulp.task('test', gulp.series('test-build'));

--- a/test/deps/files/full.example.valid.json
+++ b/test/deps/files/full.example.valid.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform",
+                "package": "npm"
+            },
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/manager.example.absent.json
+++ b/test/deps/files/manager.example.absent.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform",
+                "package": "name"
+            },
+            {
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/manager.example.incorect.json
+++ b/test/deps/files/manager.example.incorect.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform1",
+                "package": "npm"
+            },
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/manager.language.valid.json
+++ b/test/deps/files/manager.language.valid.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/manager.system.valid.json
+++ b/test/deps/files/manager.system.valid.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform",
+                "package": "npm"
+            }
+        ]
+    ]
+}

--- a/test/deps/files/package-id.example.absent.json
+++ b/test/deps/files/package-id.example.absent.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "dependencies": [
+        [
+            {
+                "manager": "platform"
+            },
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/package.example.absent.json
+++ b/test/deps/files/package.example.absent.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform"
+            },
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/files/package.example.incorect.json
+++ b/test/deps/files/package.example.incorect.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schema.linterhub.com/deps.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "dependencies": [
+        [
+            {
+                "manager": "platform",
+                "package": 1
+            },
+            {
+                "manager": "bower",
+                "package": "name",
+                "version": "1.0.0",
+                "target": true
+            }
+        ]
+    ]
+}

--- a/test/deps/test.json
+++ b/test/deps/test.json
@@ -1,0 +1,64 @@
+{
+    "description": "deps schema",
+    "$schema": { 
+        "$ref": "https://schema.linterhub.com/deps.json"
+    },
+    "tests": [
+        {
+            "description": "with full data",
+            "data": { 
+                "$ref" : "test/deps/files/full.example.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "with manager system",
+            "data": { 
+                "$ref" : "test/deps/files/manager.system.valid.json" 
+            },
+            "valid": true
+        },
+        {
+            "description": "with manager language",
+            "data": { 
+                "$ref" : "test/deps/files/manager.language.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "incorect manager name",
+            "data": { 
+                "$ref" : "test/deps/files/manager.example.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "incorect package name",
+            "data": { 
+                "$ref" : "test/deps/files/package.example.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no manager",
+            "data": { 
+                "$ref" : "test/deps/files/manager.example.absent.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no package",
+            "data": { 
+                "$ref" : "test/deps/files/package.example.absent.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no package-id",
+            "data": { 
+                "$ref" : "test/deps/files/package-id.example.absent.json"
+            },
+            "valid": false
+        }
+    ]
+}

--- a/test/linter/files/full.example.valid.json
+++ b/test/linter/files/full.example.valid.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "languages": [
+        "Text",
+        "JSP"
+    ],
+    "extensions": [
+        ".txt",
+        ".jsp"
+    ],
+    "configs": [
+        "config.json"
+    ]
+}

--- a/test/linter/files/language.collection.incorect.json
+++ b/test/linter/files/language.collection.incorect.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package-id": "url://url",
+    "languages": [
+        "Text",
+        "JSP1"
+    ]
+}

--- a/test/linter/files/language.collection.valid.json
+++ b/test/linter/files/language.collection.valid.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "languages": [
+        "Text",
+        "JSP"
+    ]
+}

--- a/test/linter/files/language.custom.incorect.json
+++ b/test/linter/files/language.custom.incorect.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package-id": "url://url",
+    "languages": [
+        "Text1"
+    ],
+    "extensions": [
+        ".txt"
+    ],
+    "configs": [
+        "config.json"
+    ]
+}

--- a/test/linter/files/language.custom.valid.json
+++ b/test/linter/files/language.custom.valid.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "languages": [
+        "JSP"
+    ],
+    "extensions": [
+        ".jsp"
+    ],
+    "configs": [
+        "config.json"
+    ]
+}

--- a/test/linter/files/language.linguist.incorect.json
+++ b/test/linter/files/language.linguist.incorect.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package-id": "url://url",
+    "languages": [
+        "CSS1"
+    ]
+}

--- a/test/linter/files/language.linguist.valid.json
+++ b/test/linter/files/language.linguist.valid.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "package": "url://url",
+    "languages": [
+        "Text"
+    ],
+    "extensions": [
+        ".txt"
+    ],
+    "configs": [
+        "config.json"
+    ]
+}

--- a/test/linter/files/package-id.example.absent.json
+++ b/test/linter/files/package-id.example.absent.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.linterhub.com/linter.json",
+    "$version": "1.0.0",
+    "languages": [
+        "Text"
+    ],
+    "extensions": [
+        ".txt"
+    ],
+    "configs": [
+        "config.json"
+    ]
+}

--- a/test/linter/test.json
+++ b/test/linter/test.json
@@ -1,0 +1,64 @@
+{
+    "description": "linter schema",
+    "$schema": { 
+        "$ref": "https://schema.linterhub.com/linter.json"
+    },
+    "tests": [
+        {
+            "description": "with full data",
+            "data": { 
+                "$ref" : "test/linter/files/full.example.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "with linguist language",
+            "data": { 
+                "$ref" : "test/linter/files/language.linguist.valid.json" 
+            },
+            "valid": true
+        },
+        {
+            "description": "with custom language",
+            "data": { 
+                "$ref" : "test/linter/files/language.custom.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "with collection of languages",
+            "data": { 
+                "$ref" : "test/linter/files/language.collection.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "incorect collection of languages",
+            "data": { 
+                "$ref" : "test/linter/files/language.collection.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "incorect custom language",
+            "data": { 
+                "$ref" : "test/linter/files/language.custom.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "incorect linguist language",
+            "data": { 
+                "$ref" : "test/linter/files/language.linguist.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no package-id",
+            "data": { 
+                "$ref" : "test/linter/files/package-id.example.absent.json"
+            },
+            "valid": false
+        } 
+    ]
+}

--- a/test/package/files/full.example.valid.json
+++ b/test/package/files/full.example.valid.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "package": "uri://uri",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "license": "Custom",
+    "copying": "copying"
+}

--- a/test/package/files/id.example.absent.json
+++ b/test/package/files/id.example.absent.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "license": "Custom",
+    "copying": "copying"
+}

--- a/test/package/files/license.custom.valid.json
+++ b/test/package/files/license.custom.valid.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "package": "uri://uri",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "license": "Custom",
+    "copying": "copying"
+}

--- a/test/package/files/license.example.absent.json
+++ b/test/package/files/license.example.absent.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "$id": "uri://uri",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "copying": "copying"
+}

--- a/test/package/files/license.example.incorect.json
+++ b/test/package/files/license.example.incorect.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "$id": "uri://uri",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "license": "MIT1",
+    "copying": "copying"
+}

--- a/test/package/files/license.spdx.valid.json
+++ b/test/package/files/license.spdx.valid.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "package": "uri://uri",
+    "name": "name",
+    "description": "description",
+    "url": "url://url",
+    "license": "MIT",
+    "copying": "copying"
+}

--- a/test/package/files/name.example.absent.json
+++ b/test/package/files/name.example.absent.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.linterhub.com/package.json",
+    "$version": "1.0.0",
+    "$id": "uri://uri",
+    "description": "description",
+    "url": "url://url",
+    "license": "Custom",
+    "copying": "copying"
+}

--- a/test/package/test.json
+++ b/test/package/test.json
@@ -1,0 +1,57 @@
+{
+    "description": "package schema",
+    "$schema": { 
+        "$ref": "https://schema.linterhub.com/package.json"
+    },
+    "tests": [
+        {
+            "description": "with full data",
+            "data": { 
+                "$ref" : "test/package/files/full.example.valid.json" 
+            },
+            "valid": true
+        },
+        {
+            "description": "with custom license",
+            "data": { 
+                "$ref" : "test/package/files/license.custom.valid.json" 
+            },
+            "valid": true
+        },
+        {
+            "description": "with SPDX license",
+            "data": { 
+                "$ref" : "test/package/files/license.spdx.valid.json"
+            },
+            "valid": true
+        },
+        {
+            "description": "incorect license",
+            "data": { 
+                "$ref" : "test/package/files/license.example.incorect.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no license",
+            "data": { 
+                "$ref" : "test/package/files/license.example.absent.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no id",
+            "data": { 
+                "$ref" : "test/package/files/id.example.absent.json"
+            },
+            "valid": false
+        },
+        {
+            "description": "no name",
+            "data": { 
+                "$ref" : "test/package/files/name.example.absent.json"
+            },
+            "valid": false
+        }
+    ]
+}


### PR DESCRIPTION
added test (for all schemas) to folder `test`. Each subfolder include test for one schema.

added next gulp commands:
- 'test-preload-build` - preload all schemas from `build` folder.

added next gulp series commands:
- `test-build` - included: `test-preload-build` and function `test`
- `test` - by default run `test-build`

Closes #22