### PR TITLE
feat: add release command

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -20,3 +20,6 @@ uri
 shipit
 pacman
 md
+json
+linterhub
+init

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,5 +21,7 @@ gulp.task('default', gulp.series(
     'validate',
     'lint',
     'build',
-    'test-build'
+    'test-build',
+    'release',
+    'test-release'
 ));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "gulp build && gulp test-build",
     "lint": "gulp lint",
     "import": "gulp import",
+    "release": "gulp release",
     "update": "git fetch && git rebase && git submodule update --remote --merge"
   },
   "husky": {

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -36,5 +36,9 @@
     "ext": {
         "linguist": "ext/github/linguist/lib/linguist/languages.yml",
         "spdx": "ext/spdx/license-list-data/json/licenses.json"
+    },
+    "release": {
+        "dir": "dist",
+        "mask": "dist/*.json"
     }
 }

--- a/script/gulp/index.js
+++ b/script/gulp/index.js
@@ -7,6 +7,7 @@ const cfg = require('./config.json');
 const amd = {
   fs: require('fs'),
   log: require('fancy-log'),
+  path: require('path'),
   git: require('gulp-git'),
   yaml: require('js-yaml'),
   eslint: require('gulp-eslint'),

--- a/script/gulp/task.release.js
+++ b/script/gulp/task.release.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const path = core.amd.path;
+const config = core.cfg;
+
+// Externally functions as aliases
+const readJson = core.fnc.readJson;
+
+// Copy to release all schemas and update root
+const createRelease = () => gulp
+    .src(config.build.mask)
+    .pipe(gulp.dest(config.release.dir))
+    .pipe(gulp.dest((file) => {
+        let content = readJson(file.path);
+        let version = content.$version;
+        return path.join(config.release.dir, version);
+    }));
+
+// Tasks
+gulp.task('create-release', createRelease);
+gulp.task('release', gulp.parallel('create-release'));

--- a/script/gulp/task.test.js
+++ b/script/gulp/task.test.js
@@ -61,7 +61,7 @@ const test = (done) => gulp
         return Promise.all(tasks);
     }));
 
-// Preload schemas in build folder
+// Preload schemas from build folder
 const buildPreload = () => gulp
     .src(config.build.mask)
     .pipe(jsonData((file) => {
@@ -70,7 +70,18 @@ const buildPreload = () => gulp
         log.info(`SCHEMA PRELOAD: ${file.path}`);
     }));
 
+// Preload schemas from release folder
+const releasePreload = () => gulp
+    .src(config.release.mask)
+    .pipe(jsonData((file) => {
+        const schema = readJson(file.path);
+        validator.addSchema(schema, schema.$id);
+        log.info(`SCHEMA PRELOAD: ${file.path}`);
+    }));
+
 // Tasks
 gulp.task('test-preload-build', buildPreload);
+gulp.task('test-preload-release', releasePreload);
 gulp.task('test-build', gulp.series('test-preload-build', test));
+gulp.task('test-release', gulp.series('test-preload-release', test));
 gulp.task('test', gulp.series('test-build'));


### PR DESCRIPTION
added next gulp commands:
- `create-release`  - compile all core schemas from build folder to release folder
- `test-preload-release` - preload all schemas from `dist` folder

added next gulp series commands:
- `test-release` - include: `test-preload-release` and function `test`
- `release` - include: `create-release`

Closes #24