### PR TITLE
ci: auto deploys core schemas to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js
+node_js: stable
+cache:
+  directories:
+    - node_modules
+git:
+  submodules: false
+before_install:
+  - git submodule update --init
+install:
+  - npm install
+script:
+  - npm run test
+  - npm run release
+deploy:
+  provider: pages
+  skip-cleanup: true
+  keep-history: true
+  github_token: $GITHUB_TOKEN
+  local-dir: dist
+  on:
+    branch: master
+    target_branch: gh-pages

--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -28,3 +28,5 @@ src
 dir
 ver
 ext
+cname
+url

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "gulp build && gulp test-build",
     "lint": "gulp lint",
     "import": "gulp import",
-    "release": "gulp release",
+    "release": "gulp release && gulp test-release",
     "update": "git fetch && git rebase && git submodule update --remote --merge"
   },
   "husky": {

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -41,6 +41,9 @@
         "dir": "dist",
         "mask": "dist/*.json"
     },
+    "assets": {
+        "cname": "CNAME"
+    },
     "node": {
         "dir": "node_modules"
     }

--- a/script/gulp/task.release.js
+++ b/script/gulp/task.release.js
@@ -11,6 +11,11 @@ const config = core.cfg;
 // Externally functions as aliases
 const readJson = core.fnc.readJson;
 
+// Copy all static assets to release
+const copyStatic = () => gulp
+    .src(config.assets.cname)
+    .pipe(gulp.dest(config.release.dir));
+
 // Copy to release all schemas and update root
 const createRelease = () => gulp
     .src(config.build.mask)
@@ -22,5 +27,6 @@ const createRelease = () => gulp
     }));
 
 // Tasks
+gulp.task('static', copyStatic);
 gulp.task('create-release', createRelease);
-gulp.task('release', gulp.parallel('create-release'));
+gulp.task('release', gulp.parallel('static', 'create-release'));


### PR DESCRIPTION
added next gulp commands:
- `static` - copy all static assets to release folder

update next gulp commands:
- `release` - add `static`  before `create-release` gulp command

added Travis with next script:
- `npm run test`
- `npm run release`
- auto deploy to gh-pages from `dist` folder

Closes #25