### PR TITLE
ci: publish package to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "tag": "beta"
+    "tag": "beta",
+    "access": "public"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Set `access` value is `public` to package.json

Closes #33