### PR TITLE
ci: add markownlint configuration file

### DIFF
--- a/.mdlrc.json
+++ b/.mdlrc.json
@@ -1,0 +1,4 @@
+{
+    "default": true,
+    "MD013": {"tables": false }
+}

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -7,6 +7,9 @@
             "node": "!**/node_modules/**",
             "ext": "!ext/**"
         },
+        "config": {
+            "markdownlint": ".mdlrc.json"
+        },
         "documentation": "**/*.md"
     },
     "template": {

--- a/script/gulp/task.lint.js
+++ b/script/gulp/task.lint.js
@@ -11,6 +11,7 @@ const config = core.cfg;
 const markdownlint = core.amd.markdownlint;
 const log = core.amd.log;
 const gulpData = core.amd.gulpData;
+const path = core.amd.path;
 
 // Lint and auto-fix all js files
 const lintJs = () => gulp
@@ -37,7 +38,11 @@ const lintMarkdown = (done) => gulp
         config.src.exclude.ext,
     ])
     .pipe(gulpData((file) => {
-        const results = markdownlint.sync({'files': [file.path]});
+        const results = markdownlint.sync({
+            'files': [file.path],
+            'config': require(
+                path.join('../../', config.src.config.markdownlint)),
+        });
         const errors = results[file.path];
         errors.map((error) => printMarkdownError(error, file));
         if (errors.length > 0 ) {


### PR DESCRIPTION
added a `markownlint` configuration file to the project  with following rules:
- `default`: `true`
- `MD013`: `tables:false`

Closes of #72 
