### PR TITLE
ci: add install all npm packages after cleanup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,11 +29,25 @@ gulp.task('validate', gulp.series('validate:all'));
 gulp.task('lint', gulp.series('lint:all'));
 
 /**
+ * Clean node_modules folder and install all npm package
+ *
+ * @task {packages:reinstall}
+ */
+gulp.task('packages:reinstall', gulp.series(
+    'clean:node',
+    'packages:install'
+));
+
+/**
  * Clean following folders: build, release and node modules
  *
  * @task {clean}
  */
-gulp.task('clean', gulp.series('clean:all'));
+gulp.task('clean', gulp.parallel(
+    'packages:reinstall',
+    'clean:build',
+    'clean:release'
+));
 
 /**
  * Import licenses and languages
@@ -71,6 +85,7 @@ gulp.task('pull', gulp.parallel('pull:all'));
  * @arg {nextRelease} [optional] version of next release. By default: 0.9.0
  */
 gulp.task('release', gulp.series(
+    'test:source',
     'build',
     'test:build',
     'clean:release',
@@ -78,7 +93,7 @@ gulp.task('release', gulp.series(
 ));
 
 /**
- * Run test for core schemas in `build` folder
+ * Run test for core schemas
  *
  * @task {test}
  */

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-git": "^2.7.0",
     "gulp-help-doc": "^1.1.1",
     "gulp-hub": "^0.8.0",
+    "gulp-install": "^1.1.0",
     "gulp-json-format": "^2.0.0",
     "gulp-json-schema": "^1.0.0",
     "gulp-jsonschema-bundle": "0.0.3",

--- a/script/gulp/config.json
+++ b/script/gulp/config.json
@@ -57,5 +57,8 @@
     },
     "meta": {
         "version": "0.9.0"
+    },
+    "root": {
+        "package": "./package.json"
     }
 }

--- a/script/gulp/index.js
+++ b/script/gulp/index.js
@@ -18,6 +18,7 @@ const amd = {
   hubRegistry: require('gulp-hub'),
   markdownlint: require('markdownlint'),
   gulpData: require('gulp-data'),
+  gulpInstall: require('gulp-install'),
   gulpHelpDoc: require('gulp-help-doc'),
   jsonFormat: require('gulp-json-format'),
   jsonSchema: require('gulp-json-schema'),

--- a/script/gulp/task.clean.js
+++ b/script/gulp/task.clean.js
@@ -27,8 +27,3 @@ const cleanNode = () => del([
 gulp.task('clean:node', cleanNode);
 gulp.task('clean:build', cleanBuild);
 gulp.task('clean:release', cleanRelease);
-gulp.task('clean:all', gulp.parallel(
-    'clean:node',
-    'clean:build',
-    'clean:release'
-));

--- a/script/gulp/task.install.js
+++ b/script/gulp/task.install.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Get shared core
+const core = global.lhcore;
+
+// External modules as aliases
+const gulp = core.amd.gulp;
+const config = core.cfg;
+const gulpInstall = core.amd.gulpInstall;
+
+// Automatically install npm packages with --save-dev flag
+const itself = () => gulp
+    .src(config.root.package)
+    .pipe(gulpInstall());
+
+// Tasks
+gulp.task('packages:install', itself);

--- a/script/gulp/task.test.js
+++ b/script/gulp/task.test.js
@@ -19,11 +19,12 @@ const testTrue = (test, schema, done) => {
     if (test.valid) {
         log.info(`OK: ${schema.description} ${test.description}`);
     } else {
+        const errorMessage = `MESSAGE: Validation failed`;
         log.error(`FAIL: ${schema.description} ${test.description}`);
         log.error(`FILE: ${test.data.$ref}`);
-        log.error(`MESSAGE: Validation failed`);
+        log.error(errorMessage);
+        done(errorMessage);
     }
-    done();
 };
 
 // If result of test is false
@@ -46,9 +47,9 @@ const runTest = (test, schema, done) => {
     const data = readJson(test.data.$ref);
     const result = validator.validate(data, schema.$schema.$ref);
     if (result.errors && result.errors.length) {
-        testFalse(test, schema, done, result);
+       testFalse(test, schema, done, result);
     } else {
-        testTrue(test, schema, done);
+       testTrue(test, schema, done);
     }
 };
 


### PR DESCRIPTION
added next gulp commands:
- `install:npm` - installing all npm packages from `package.json`. Use only with another gulp task.

Closes #90