### PR TITLE
 fix: fix the minLength property in deps schema

### DIFF
--- a/src/schema/deps.json
+++ b/src/schema/deps.json
@@ -21,7 +21,7 @@
             "items": {
                 "$ref": "#/definitions/package"
             },
-            "minLength": 1,
+            "minItems": 1,
             "uniqueItems": true
         },
         "package": {


### PR DESCRIPTION
Change `minLength` property to `minItems` in the deps schema

Closes #108