### PR TITLE
ci: fix exports core schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-exports = {
+exports = module.exports = {
     collection: require('./dist/collection.json'),
     deps: require('./dist/deps.json'),
     linter: require('./dist/linter.json'),
     package: require('./dist/package.json'),
     schemaver: require('./dist/schemaver.json'),
+    import: require('./dist/import.json'),
 };


### PR DESCRIPTION
Fixed exports core schemas in `index.js` file

Closes #158
