### PR TITLE
fix: fix validate objects properties in args schema

### DIFF
--- a/src/schema/args.json
+++ b/src/schema/args.json
@@ -145,9 +145,16 @@
                             "title": "Object",
                             "description": "The arguments object schema",
                             "type": "object",
-                            "patternProperties": {
-                                "^[-a-z]+$|^$": {
-                                    "$ref": "#/definitions/arg"
+                            "properties": {
+                                "properties": {
+                                    "title": "Properties",
+                                    "description": "The arguments properties of package",
+                                    "type": "object",
+                                    "patternProperties": {
+                                        "^[-a-z]+$|^$": {
+                                            "$ref": "#/definitions/arg"
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixed validate objects properties in `args.json` core schema

Closes #171
