### PR TITLE
feat: add new properties to linter.json schema

### DIFF
--- a/src/schema/linter.json
+++ b/src/schema/linter.json
@@ -62,6 +62,22 @@
                         "$ref": "#/definitions/config"
                     },
                     "uniqueItems": true
+                },
+                "url": {
+                    "title": "URL",
+                    "description": "The linter homepage",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "license": {
+                    "title": "License",
+                    "description": "The linter license",
+                    "$ref": "./collection.json#/definitions/license"
+                },
+                "description": {
+                    "title": "Description",
+                    "description": "The linter description",
+                    "type": "string"
                 }
             },
             "required": [


### PR DESCRIPTION
Added following properties to `linter.json` schema:
- description - the linter description
- license - the linter license
- URL - the linter homepage

Closes #187
